### PR TITLE
feat: 전자결재 등록 및 상세 조회 페이지 작업

### DIFF
--- a/src/assets/Theme-variable.js
+++ b/src/assets/Theme-variable.js
@@ -71,8 +71,7 @@ const baseTheme = createTheme({
       styleOverrides: {
         root: {
           paddingLeft: "15px !important",
-          paddingRight: "15px !important",
-          maxWidth: "1600px",
+          paddingRight: "15px !important"
         },
       },
     },

--- a/src/components/approval/ApprovalDetailMenu.jsx
+++ b/src/components/approval/ApprovalDetailMenu.jsx
@@ -1,0 +1,36 @@
+import { Button, Stack } from '@mui/material';
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const ApprovalDetailMenu = ({type, backHistory = null}) => {
+  const navigate = useNavigate();
+  const backHistoryClick = () => {
+    console.log(backHistory)
+    if(backHistory === null){
+      navigate(-1);
+    } else {
+      navigate(backHistory);
+    }
+  }
+
+  return (
+    <>
+      {type === "기안" ?(
+        <Stack direction="row" spacing={1}>
+          <Button variant='h5'>상신취소</Button>
+          <Button variant='h5'>결재정보</Button>
+          <Button variant='h5' onClick={backHistoryClick}>목록</Button>
+        </Stack>
+      ) : (
+        <Stack direction="row" spacing={1}>
+          <Button variant='h5'>결재</Button>
+          <Button variant='h5'>반려</Button>
+          <Button variant='h5'>결재정보</Button>
+          <Button variant='h5' onClick={backHistoryClick}>목록</Button>
+        </Stack>
+      )}
+    </>
+  );
+};
+
+export default ApprovalDetailMenu;

--- a/src/components/approval/ApprovalSideBar.jsx
+++ b/src/components/approval/ApprovalSideBar.jsx
@@ -1,0 +1,68 @@
+import { Box, Button, Stack, Typography } from '@mui/material';
+import React, { useState } from 'react';
+import ModalPortal from '../../config/ModalPortal';
+import FormModal from './FormModal';
+import { useNavigate } from 'react-router-dom';
+
+const ApprovalSideBar = ({setApprovalData = null}) => {
+  const navigate = useNavigate();
+  const [modal, setModal] = useState(false);
+
+  const changeForm = (data) => {
+    if(setApprovalData !== null){
+      setApprovalData(data);
+    }
+    navigate("/approval/draft/form", {state: { approvalData: data } });
+    setModal(false);
+  }
+
+  const onModal = () => {
+    setModal(!modal);
+  }
+
+  return (
+    <>
+      <Stack>
+        <Box sx={{width:"200px"}}>
+          <Typography variant='h2'>전자결재</Typography>
+          <Box display="flex" alignItems="center" my={2}>
+            <Button variant='contained' color='success' sx={{width:"90%", margin:"auto", height:"45px"}} onClick={onModal}>새 결재 진행</Button>
+          </Box>
+          <Box sx={{marginTop: "20px"}}>
+            <Typography variant='h5' sx={{fontWeight:"bold"}}>자주 쓰는 양식</Typography>
+            <Typography variant='h6' sx={{marginLeft:"15px"}}>휴가 신청</Typography>
+            <Typography variant='h6' sx={{marginLeft:"15px"}}>업무 기안</Typography>
+            <Typography variant='h6' sx={{marginLeft:"15px"}}>(신규)휴가신청-연차관리연동</Typography>
+            <Typography variant='h6' sx={{marginLeft:"15px"}}>(신규)연장근무신청-근태관리연동</Typography>
+          </Box>
+          <Box sx={{marginTop: "20px"}}>
+            <Typography variant='h5' sx={{fontWeight:"bold"}}>자주 쓰는 양식</Typography>
+            <Typography variant='h6' sx={{marginLeft:"15px"}}>휴가 신청</Typography>
+            <Typography variant='h6' sx={{marginLeft:"15px"}}>업무 기안</Typography>
+            <Typography variant='h6' sx={{marginLeft:"15px"}}>(신규)휴가신청-연차관리연동</Typography>
+            <Typography variant='h6' sx={{marginLeft:"15px"}}>(신규)연장근무신청-근태관리연동</Typography>
+          </Box>
+          <Box sx={{marginTop: "20px"}}>
+            <Typography variant='h5' sx={{fontWeight:"bold"}}>자주 쓰는 양식</Typography>
+            <Typography variant='h6' sx={{marginLeft:"15px"}}>휴가 신청</Typography>
+            <Typography variant='h6' sx={{marginLeft:"15px"}}>업무 기안</Typography>
+            <Typography variant='h6' sx={{marginLeft:"15px"}}>(신규)휴가신청-연차관리연동</Typography>
+            <Typography variant='h6' sx={{marginLeft:"15px"}}>(신규)연장근무신청-근태관리연동</Typography>
+          </Box>
+          <Box sx={{marginTop: "20px"}}>
+            <Typography variant='h5' sx={{fontWeight:"bold"}}>자주 쓰는 양식</Typography>
+            <Typography variant='h6' sx={{marginLeft:"15px"}}>휴가 신청</Typography>
+            <Typography variant='h6' sx={{marginLeft:"15px"}}>업무 기안</Typography>
+            <Typography variant='h6' sx={{marginLeft:"15px"}}>(신규)휴가신청-연차관리연동</Typography>
+            <Typography variant='h6' sx={{marginLeft:"15px"}}>(신규)연장근무신청-근태관리연동</Typography>
+          </Box>
+        </Box>
+      </Stack>
+      <ModalPortal>
+        {modal && <FormModal onModal={onModal} changeForm={changeForm}/>}
+      </ModalPortal>
+    </>
+  );
+};
+
+export default ApprovalSideBar;

--- a/src/modules/redux/approval.js
+++ b/src/modules/redux/approval.js
@@ -2,23 +2,54 @@ import { createAsyncThunk, createSlice } from "@reduxjs/toolkit"
 import axios from "axios"
 
 const initialState = {
-    data: {},
-    formList: [],
-    isLoading: false,
-    error: null
+  data: {},
+  approval: {},
+  approvalList: [],
+  formList: [],
+  isLoading: false,
+  error: null
 }
 
+//결재 양식 폼 목록 조회
 export const _getFormList = createAsyncThunk(
-    "approval/getFormList",
-    async (payload, thunkAPI) => {
-        try{
-            const data = await axios.get("http://localhost:9000/app/approval/form");
-            return thunkAPI.fulfillWithValue(data.data.data);
-        } catch(e){
-            return thunkAPI.rejectWithValue(e);
-        }
-    }
+  "approval/getFormList",
+  async (payload, thunkAPI) => {
+      try{
+          const data = await axios.get("http://localhost:9000/app/approval/form");
+          return thunkAPI.fulfillWithValue(data.data.data);
+      } catch(e){
+          return thunkAPI.rejectWithValue(e);
+      }
+  }
 );
+
+//기안문 등록
+export const _createApproval = createAsyncThunk(
+  "approval/createApproval",
+  async (payload, thunkAPI) => {
+    try {
+      const data = await axios.post("http://localhost:9000/app/approval/draft", payload.formData);
+      payload._navigate(`/approval/draft/detail/${data.data.data.approvalId}`, {replace: true, state: {history: "/approval/draft"}});
+      return thunkAPI.fulfillWithValue(data.data.data);
+    } catch(e){
+      return thunkAPI.rejectWithValue(e);
+    }
+  }
+);
+
+//기안문 상세조회
+export const _getApprovalDetail = createAsyncThunk(
+  "approval/getApprovalDetail",
+  async (payload, thunkAPI) => {
+    try{
+      const data = await axios.get(`http://localhost:9000/app/approval/draft/doc/${payload}`);
+      return thunkAPI.fulfillWithValue(data.data.data);
+    } catch(e){
+      return thunkAPI.rejectWithValue(e);
+    }
+  }
+);
+
 
 export const approvalSlice = createSlice({
     name: "approval",
@@ -34,6 +65,30 @@ export const approvalSlice = createSlice({
                 state.data = action.payload;
             })
             .addCase(_getFormList.rejected, (state, action) => {
+                state.isLoading = false;
+                state.error = action.payload;
+            })
+        builder
+            .addCase(_createApproval.pending, (state) => {
+                state.isLoading = true;
+            })
+            .addCase(_createApproval.fulfilled, (state, action) => {
+                state.isLoading = false;
+                state.approval = action.payload;
+            })
+            .addCase(_createApproval.rejected, (state, action) => {
+                state.isLoading = false;
+                state.error = action.payload;
+            })
+        builder
+            .addCase(_getApprovalDetail.pending, (state) => {
+                state.isLoading = true;
+            })
+            .addCase(_getApprovalDetail.fulfilled, (state, action) => {
+                state.isLoading = false;
+                state.approval = action.payload;
+            })
+            .addCase(_getApprovalDetail.rejected, (state, action) => {
                 state.isLoading = false;
                 state.error = action.payload;
             })

--- a/src/pages/approval/ApprovalDetail.jsx
+++ b/src/pages/approval/ApprovalDetail.jsx
@@ -1,0 +1,49 @@
+import { Box, Stack, Typography } from '@mui/material';
+import parse from 'html-react-parser';
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useLocation, useParams } from 'react-router-dom';
+import { _getApprovalDetail } from '../../modules/redux/approval';
+import ApprovalSideBar from '../../components/approval/ApprovalSideBar';
+import ApprovalDetailMenu from '../../components/approval/ApprovalDetailMenu';
+
+
+const ApprovalDetail = () => {
+  const dispatch = useDispatch();
+  const location = useLocation();
+  const [backHistory, setBackHistory] = useState(location.state?.history || null);
+  const {id} = useParams();
+  const {isLoading, error, approval = {}} = useSelector((state) => state.approval);
+
+  useEffect(() => {
+    dispatch(_getApprovalDetail(id));
+
+    if (isLoading) {
+      return <div>로딩중....</div>;
+    }
+  
+    if (error) {
+        return <div>{error.message}</div>;
+    }
+  },[]);
+
+
+
+  return (
+    <Stack direction="row" spacing={4} sx={{marginLeft: "0"}}>
+      <ApprovalSideBar />
+      <Stack>
+        <Box sx={{marginBottom:"15px"}}>
+          <Typography variant='h2'>{approval.subject}</Typography>
+        </Box>
+        <ApprovalDetailMenu type={approval.approvalType} backHistory={backHistory}/>
+        <Box sx={{border: "3px solid gray", padding: "50px", marginTop:"10px", marginBottom:"10px"}}>
+          <div>{parse(approval.docBody || "")}</div>
+        </Box>
+        <ApprovalDetailMenu type={approval.approvalType} backHistory={backHistory}/>
+      </Stack>
+    </Stack>
+  )
+};
+
+export default ApprovalDetail;


### PR DESCRIPTION
- 등록 페이지에 임시 데이터로 결재자, 기안자 설정(추후에 JWT 및 결재라인  작업 완료 후 수정 예정)
- 상세 조회 페이지 기안자, 결재자 구분 없이 데이터만 불러오는 작업 진행 완료(추후에 결재자, 기안자 구분 로직 필요)